### PR TITLE
Use flex wrap style to improve mobile rendering

### DIFF
--- a/src/components/CouponMarket/Header.tsx
+++ b/src/components/CouponMarket/Header.tsx
@@ -13,14 +13,14 @@ type CouponMarketHeaderProps = {
 const CouponMarketHeader = ({
   debt, supply, premium
 }: CouponMarketHeaderProps) => (
-  <div style={{ padding: '2%', display: 'flex', alignItems: 'center' }}>
-    <div style={{ width: '25%' }}>
+  <div style={{ padding: '2%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+    <div style={{ flexBasis: '25%' }}>
       <BalanceBlock asset="Total Debt" balance={debt} suffix={"ESD"}/>
     </div>
-    <div style={{ width: '25%' }}>
+    <div style={{ flexBasis: '25%' }}>
       <BalanceBlock asset="Debt Ratio" balance={ownership(debt, supply)} suffix={"%"}/>
     </div>
-    <div style={{ width: '25%' }}>
+    <div style={{ flexBasis: '25%' }}>
       <BalanceBlock asset="Premium" balance={premium.multipliedBy(100)} suffix={"%"}/>
     </div>
   </div>

--- a/src/components/CouponMarket/PurchaseCoupons.tsx
+++ b/src/components/CouponMarket/PurchaseCoupons.tsx
@@ -41,16 +41,16 @@ function PurchaseCoupons({
   return (
     <Box heading="Purchase">
       {allowance.comparedTo(MAX_UINT256) === 0 ?
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* User balance */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset={`Balance`} balance={balance} suffix={" ESD"}/>
           </div>
-          <div style={{width: '38%'}}/>
+          <div style={{flexBasis: '38%'}}/>
           {/* Purchase coupons */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '6em'}}>
                 <>
                   <BigNumberInput
                     adornment="ESD"
@@ -69,7 +69,7 @@ function PurchaseCoupons({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '6em'}}>
                 <Button
                   wide
                   icon={<IconCircleMinus/>}
@@ -88,14 +88,14 @@ function PurchaseCoupons({
           </div>
         </div>
         :
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* User balance */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset={`Døllar Balance`} balance={balance}/>
           </div>
-          <div style={{width: '40%'}}/>
+          <div style={{flexBasis: '40%'}}/>
           {/* Approve DAO to spend Døllar */}
-          <div style={{width: '30%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '30%', paddingTop: '2%'}}>
             <Button
               wide
               icon={<IconCirclePlus/>}

--- a/src/components/Governance/Header.tsx
+++ b/src/components/Governance/Header.tsx
@@ -17,17 +17,17 @@ const STATUS_MAP = ["Frozen", "Fluid", "Locked"];
 const GovernanceHeader = ({
   stake, totalStake, accountStatus, implementation
 }: GovernanceHeaderProps) => (
-  <div style={{ padding: '2%', display: 'flex', alignItems: 'center' }}>
-    <div style={{ width: '25%' }}>
+  <div style={{ padding: '2%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+    <div style={{ flexBasis: '25%' }}>
       <BalanceBlock asset="DAO Ownership" balance={ownership(stake, totalStake)} suffix="%" />
     </div>
-    <div style={{ width: '25%' }}>
+    <div style={{ flexBasis: '25%' }}>
       <BalanceBlock asset="Proposal Threshold" balance={new BigNumber("1.00")} suffix="%" />
     </div>
-    <div style={{ width: '25%' }}>
+    <div style={{ flexBasis: '25%' }}>
       <TextBlock label="Status" text={STATUS_MAP[accountStatus]}/>
     </div>
-    <div style={{ width: '25%' }}>
+    <div style={{ flexBasis: '25%' }}>
       <AddressBlock label="Implementation" address={implementation} />
     </div>
   </div>

--- a/src/components/Governance/ProposeCandidate.tsx
+++ b/src/components/Governance/ProposeCandidate.tsx
@@ -29,9 +29,9 @@ function ProposeCandidate({
 
   return (
     <Box heading="Propose">
-      <div style={{display: 'flex'}}>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
         {/* User balance */}
-        <div style={{width: '62%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '62%', paddingTop: '2%'}}>
           <>
             <TextInput
               wide
@@ -46,9 +46,9 @@ function ProposeCandidate({
             />
           </>
         </div>
-        <div style={{width: '6%'}}/>
+        <div style={{flexBasis: '6%'}}/>
         {/* Purchase coupons */}
-        <div style={{width: '32%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '32%', paddingTop: '2%'}}>
           <Button
             wide
             icon={<IconToken/>}

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -56,19 +56,19 @@ function HomePage({user}: HomePageProps) {
 
   return (
     <>
-      <div style={{ padding: '1%', display: 'flex', alignItems: 'center' }}>
-        <div style={{ width: '30%', marginLeft: '3%'  }}>
+      <div style={{ padding: '1%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+        <div style={{ flexBasis: '30%', marginLeft: '3%' }}>
           <Header primary="døllar." />
         </div>
-        <div style={{ width: '35%' }} />
-        <div style={{ width: '30%', marginRight: '2%', textAlign: 'right'}}>
+        <div style={{ flexBasis: '35%' }} />
+        <div style={{ flexBasis: '30%', flexGrow: 1, marginRight: '2%', textAlign: 'right'}}>
           <Box>
             <EpochBlock epoch={epochTime}/>
           </Box>
         </div>
       </div>
-      <div style={{ padding: '1%', display: 'flex', alignItems: 'center' }}>
-        <div style={{ width: '30%', marginRight: '3%', marginLeft: '2%'  }}>
+      <div style={{ padding: '1%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+        <div style={{ flexBasis: '30%', marginRight: '3%', marginLeft: '2%'  }}>
           <MainButton
             title="Wallet"
             description="Manage døllar balance and bonding."
@@ -79,7 +79,7 @@ function HomePage({user}: HomePageProps) {
           />
         </div>
 
-        <div style={{ width: '30%' }}>
+        <div style={{ flexBasis: '30%' }}>
           <MainButton
             title="Governance"
             description="Vote on upgrades."
@@ -90,7 +90,7 @@ function HomePage({user}: HomePageProps) {
           />
         </div>
 
-        <div style={{ width: '30%', marginLeft: '3%', marginRight: '2%' }}>
+        <div style={{ flexBasis: '30%', marginLeft: '3%', marginRight: '2%' }}>
           <MainButton
             title="Regulation"
             description="Network supply regulation statistics."
@@ -101,8 +101,8 @@ function HomePage({user}: HomePageProps) {
           />
         </div>
       </div>
-      <div style={{ padding: '1%', display: 'flex', alignItems: 'center' }}>
-        <div style={{ width: '30%', marginRight: '3%', marginLeft: '2%'  }}>
+      <div style={{ padding: '1%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+        <div style={{ flexBasis: '30%', marginRight: '3%', marginLeft: '2%'  }}>
           <MainButton
             title="Trade"
             description="Trade døllar tokens."
@@ -113,7 +113,7 @@ function HomePage({user}: HomePageProps) {
           />
         </div>
 
-        <div style={{ width: '30%' }}>
+        <div style={{ flexBasis: '30%' }}>
           <MainButton
             title="LP Rewards"
             description="Earn rewards for providing liquidity."
@@ -124,7 +124,7 @@ function HomePage({user}: HomePageProps) {
           />
         </div>
 
-        <div style={{ width: '30%', marginLeft: '3%', marginRight: '2%'  }}>
+        <div style={{ flexBasis: '30%', marginLeft: '3%', marginRight: '2%'  }}>
           <MainButton
             title="Coupons"
             description="Purchase and redeem coupons."

--- a/src/components/Pool/BondUnbond.tsx
+++ b/src/components/Pool/BondUnbond.tsx
@@ -27,19 +27,19 @@ function BondUnbond({
 
   return (
     <Box heading="Bond">
-      <div style={{display: 'flex'}}>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
         {/* Total bonded */}
-        <div style={{width: '16%'}}>
+        <div style={{flexBasis: '16%'}}>
           <BalanceBlock asset="Bonded" balance={bonded} suffix={"UNI-V2"} />
         </div>
         {/* Exit lockup */}
-        <div style={{width: '16%'}}>
+        <div style={{flexBasis: '16%'}}>
           <TextBlock label="Exit Lockup" text={lockup == 0 ? "" : lockup == 1 ? "1 epoch" : `${lockup} epochs`}/>
         </div>
         {/* Bond UNI-V2 within Pool */}
-        <div style={{width: '33%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '33%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
-            <div style={{width: '60%'}}>
+            <div style={{width: '60%', minWidth: '6em'}}>
               <>
                 <BigNumberInput
                   adornment="UNI-V2"
@@ -53,7 +53,7 @@ function BondUnbond({
                 />
               </>
             </div>
-            <div style={{width: '40%'}}>
+            <div style={{width: '40%', minWidth: '7em'}}>
               <Button
                 wide
                 icon={<IconCirclePlus/>}
@@ -70,11 +70,11 @@ function BondUnbond({
             </div>
           </div>
         </div>
-        <div style={{width: '2%'}}/>
+        <div style={{flexBasis: '2%'}}/>
         {/* Unbond UNI-V2 within Pool */}
-        <div style={{width: '33%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '33%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
-            <div style={{width: '60%'}}>
+            <div style={{width: '60%', minWidth: '6em'}}>
               <>
                 <BigNumberInput
                   adornment="UNI-V2"
@@ -88,7 +88,7 @@ function BondUnbond({
                 />
               </>
             </div>
-            <div style={{width: '40%'}}>
+            <div style={{width: '40%', minWidth: '7em'}}>
               <Button
                 wide
                 icon={<IconCircleMinus/>}

--- a/src/components/Pool/Claim.tsx
+++ b/src/components/Pool/Claim.tsx
@@ -24,16 +24,16 @@ function Claim({
 
   return (
     <Box heading="Claim">
-      <div style={{display: 'flex'}}>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
         {/* total Issued */}
-        <div style={{width: '30%'}}>
+        <div style={{flexBasis: '30%'}}>
           <BalanceBlock asset="Claimable" balance={claimable} suffix={"ESD"} />
         </div>
         {/* Deposit UNI-V2 into Pool */}
         <div style={{width: '38%'}}/>
-        <div style={{width: '32%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '32%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
-            <div style={{width: '60%'}}>
+            <div style={{width: '60%', minWidth: '6em'}}>
               <>
                 <BigNumberInput
                   adornment="ESD"
@@ -48,7 +48,7 @@ function Claim({
                 />
               </>
             </div>
-            <div style={{width: '40%'}}>
+            <div style={{width: '40%', minWidth: '6em'}}>
               <Button
                 wide
                 icon={<IconArrowDown/>}

--- a/src/components/Pool/Header.tsx
+++ b/src/components/Pool/Header.tsx
@@ -19,20 +19,20 @@ const STATUS_MAP = ["Frozen", "Fluid"];
 const PoolPageHeader = ({
   accountUNIBalance, accountBondedBalance, accountRewardedESDBalance, accountClaimableESDBalance, poolTotalBonded, accountPoolStatus
 }: PoolPageHeaderProps) => (
-  <div style={{ padding: '2%', display: 'flex', alignItems: 'center' }}>
-    <div style={{ width: '20%' }}>
+  <div style={{ padding: '2%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Balance" balance={accountUNIBalance}  suffix={" UNI-V2"}/>
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Rewarded" balance={accountRewardedESDBalance} suffix={" ESD"} />
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Claimable" balance={accountClaimableESDBalance} suffix={" ESD"} />
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Pool Ownership" balance={ownership(accountBondedBalance, poolTotalBonded)}  suffix={"%"}/>
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <TextBlock label="Pool Status" text={STATUS_MAP[accountPoolStatus]}/>
     </div>
   </div>

--- a/src/components/Pool/Migrate.tsx
+++ b/src/components/Pool/Migrate.tsx
@@ -28,9 +28,9 @@ function Migrate({
 
   return (
     <Box heading="Migrate">
-      <div style={{display: 'flex'}}>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
         {/* Unbond UNI-V2 within Pool */}
-        <div style={{width: '32%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '32%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
             <div style={{width: '60%'}}>
               <BalanceBlock asset="Bonded" balance={bonded} suffix={"UNI-V2"} />
@@ -51,7 +51,7 @@ function Migrate({
           </div>
         </div>
         {/* Withdraw UNI-V2 within Pool */}
-        <div style={{width: '32%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '32%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
             <div style={{width: '60%'}}>
               <BalanceBlock asset="Staged" balance={staged} suffix={"UNI-V2"} />
@@ -72,7 +72,7 @@ function Migrate({
           </div>
         </div>
         {/* Claim ESD within Pool */}
-        <div style={{width: '32%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '32%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
             <div style={{width: '60%'}}>
               <BalanceBlock asset="Claimable" balance={claimable} suffix={"ESD"} />

--- a/src/components/Pool/Provide.tsx
+++ b/src/components/Pool/Provide.tsx
@@ -51,19 +51,19 @@ function Provide({
   return (
     <Box heading="Provide">
       {userUSDCAllowance.comparedTo(MAX_UINT256.dividedBy(2)) > 0 ?
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total rewarded */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Rewarded" balance={rewarded} suffix={"ESD"} />
           </div>
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="USDC Balance" balance={userUSDCBalance} suffix={"USDC"} />
           </div>
           <div style={{width: '8%'}}/>
           {/* Provide liquidity using Pool rewards */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '6em'}}>
                 <>
                   <BigNumberInput
                     adornment="ESD"
@@ -79,7 +79,7 @@ function Provide({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '6em'}}>
                 <Button
                   wide
                   icon={<IconArrowUp/>}
@@ -98,17 +98,17 @@ function Provide({
           </div>
         </div>
         :
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total rewarded */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Rewarded" balance={rewarded} suffix={"ESD"} />
           </div>
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="USDC Balance" balance={userUSDCBalance} suffix={"USDC"} />
           </div>
           <div style={{width: '8%'}}/>
           {/* Approve Pool to spend USDC */}
-          <div style={{width: '30%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '30%', paddingTop: '2%'}}>
             <Button
               wide
               icon={<IconCirclePlus/>}

--- a/src/components/Pool/WithdrawDeposit.tsx
+++ b/src/components/Pool/WithdrawDeposit.tsx
@@ -30,15 +30,15 @@ function WithdrawDeposit({
   return (
     <Box heading="Stage">
       {allowance.comparedTo(MAX_UINT256) === 0 ?
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total Issued */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Staged" balance={stagedBalance} suffix={"UNI-V2"}/>
           </div>
           {/* Deposit UNI-V2 into Pool */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '6em'}}>
                 <>
                   <BigNumberInput
                     adornment="UNI-V2"
@@ -53,7 +53,7 @@ function WithdrawDeposit({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '7em'}}>
                 <Button
                   wide
                   icon={<IconCirclePlus/>}
@@ -72,9 +72,9 @@ function WithdrawDeposit({
           </div>
           <div style={{width: '6%'}}/>
           {/* Withdraw Døllar from DAO */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '6em'}}>
                 <>
                   <BigNumberInput
                     adornment="UNI-V2"
@@ -89,7 +89,7 @@ function WithdrawDeposit({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '7em'}}>
                 <Button
                   wide
                   icon={<IconCircleMinus/>}
@@ -108,14 +108,14 @@ function WithdrawDeposit({
           </div>
         </div>
         :
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total Issued */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Staged" balance={stagedBalance} suffix={"UNI-V2"}/>
           </div>
-          <div style={{width: '40%'}}/>
+          <div style={{flexBasis: '40%'}}/>
           {/* Approve Pool to spend UNI-V2 */}
-          <div style={{width: '30%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '30%', paddingTop: '2%'}}>
             <Button
               wide
               icon={<IconCirclePlus />}

--- a/src/components/Regulation/Header.tsx
+++ b/src/components/Regulation/Header.tsx
@@ -40,68 +40,68 @@ const RegulationHeader = ({
   return (
     <>
       <Box heading="Supply Allocation">
-        <div style={{display: 'flex'}}>
-          <div style={{ width: '25%' }}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Total" balance={totalSupply} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="DAO" balance={ownership(daoTotalSupply, totalSupply)} suffix="%" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Oracle" balance={ownership(poolTotalSupply, totalSupply)} suffix="%" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Circulating" balance={ownership(circulatingSupply, totalSupply)} suffix="%" />
           </div>
         </div>
       </Box>
 
       <Box heading="DAO Breakdown">
-        <div style={{display: 'flex'}}>
-          <div style={{ width: '25%' }}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Total" balance={daoTotalSupply} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Staged" balance={totalStaged} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Bonded" balance={totalBonded} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Redeemable" balance={totalRedeemable} suffix="" />
           </div>
         </div>
       </Box>
 
       <Box heading="Oracle Breakdown">
-        <div style={{display: 'flex'}}>
-          <div style={{ width: '25%' }}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Total" balance={poolTotalSupply} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Liquidity" balance={poolLiquidity} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Rewarded" balance={poolRewarded} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Claimable" balance={poolClaimable} suffix="" />
           </div>
         </div>
       </Box>
 
       <Box heading="Coupon Breakdown">
-        <div style={{display: 'flex'}}>
-          <div style={{ width: '25%' }}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Debt Ratio" balance={ownership(totalDebt, totalSupply)} suffix="%" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Debt" balance={totalDebt} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Coupons" balance={totalCoupons} suffix="" />
           </div>
-          <div style={{ width: '25%' }}>
+          <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Premium" balance={couponPremium.multipliedBy(100)} suffix="%" />
           </div>
         </div>

--- a/src/components/Trade/Header.tsx
+++ b/src/components/Trade/Header.tsx
@@ -15,17 +15,17 @@ const TradePageHeader = ({
   const price = pairBalanceUSDC.dividedBy(pairBalanceESD);
 
   return (
-    <div style={{ padding: '2%', display: 'flex', alignItems: 'center' }}>
-      <div style={{ width: '25%' }}>
+    <div style={{ padding: '2%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+      <div style={{ flexBasis: '25%' }}>
         <BalanceBlock asset="ESD Price" balance={price} suffix={"USDC"}/>
       </div>
-      <div style={{ width: '25%' }}>
+      <div style={{ flexBasis: '25%' }}>
         <BalanceBlock asset="ESD Liquidity" balance={pairBalanceESD} suffix={"ESD"}/>
       </div>
-      <div style={{ width: '25%' }}>
+      <div style={{ flexBasis: '25%' }}>
         <BalanceBlock asset="USDC Liquidity" balance={pairBalanceUSDC} suffix={"USDC"}/>
       </div>
-      <div style={{ width: '25%' }}>
+      <div style={{ flexBasis: '25%' }}>
         <>
           <AddressBlock label="Uniswap Contract" address={uniswapPair} />
         </>

--- a/src/components/Trade/index.tsx
+++ b/src/components/Trade/index.tsx
@@ -132,8 +132,8 @@ function UniswapPool({ user }: {user: string}) {
         uniswapPair={UNI.addr}
       />
 
-      <div style={{ padding: '1%', display: 'flex', alignItems: 'center' }}>
-        <div style={{ width: '30%', marginRight: '3%', marginLeft: '2%'  }}>
+      <div style={{ padding: '1%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+        <div style={{ flexBasis: '30%', marginRight: '3%', marginLeft: '2%'  }}>
           <MainButton
             title="Info"
             description="View ESD-USDC pool stats."
@@ -142,7 +142,7 @@ function UniswapPool({ user }: {user: string}) {
           />
         </div>
 
-        <div style={{ width: '30%' }}>
+        <div style={{ flexBasis: '30%' }}>
           <MainButton
             title="Trade"
             description="Trade døllar tokens."
@@ -151,7 +151,7 @@ function UniswapPool({ user }: {user: string}) {
           />
         </div>
 
-        <div style={{ width: '30%', marginLeft: '3%', marginRight: '2%' }}>
+        <div style={{ flexBasis: '30%', marginLeft: '3%', marginRight: '2%' }}>
           <MainButton
             title="Supply"
             description="Supply and redeem liquidity."

--- a/src/components/Wallet/BondUnbond.tsx
+++ b/src/components/Wallet/BondUnbond.tsx
@@ -27,19 +27,19 @@ function BondUnbond({
 
   return (
     <Box heading="Bond">
-      <div style={{display: 'flex'}}>
+      <div style={{display: 'flex', flexWrap: 'wrap'}}>
         {/* Total bonded */}
-        <div style={{width: '16%'}}>
+        <div style={{flexBasis: '16%'}}>
           <BalanceBlock asset="Bonded" balance={bonded} suffix={"ESD"}/>
         </div>
         {/* Total bonded */}
-        <div style={{width: '16%'}}>
+        <div style={{flexBasis: '16%'}}>
           <TextBlock label="Exit Lockup" text={lockup == 0 ? "" : lockup == 1 ? "1 epoch" : `${lockup} epochs`}/>
         </div>
         {/* Bond Døllar within DAO */}
-        <div style={{width: '33%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '33%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
-            <div style={{width: '60%'}}>
+            <div style={{width: '60%', minWidth: '6em'}}>
               <>
                 <BigNumberInput
                   adornment="ESD"
@@ -54,7 +54,7 @@ function BondUnbond({
                 />
               </>
             </div>
-            <div style={{width: '40%'}}>
+            <div style={{width: '40%', minWidth: '7em'}}>
               <Button
                 wide
                 icon={<IconCirclePlus/>}
@@ -72,9 +72,9 @@ function BondUnbond({
         </div>
         <div style={{width: '2%'}}/>
         {/* Unbond Døllar within DAO */}
-        <div style={{width: '33%', paddingTop: '2%'}}>
+        <div style={{flexBasis: '33%', paddingTop: '2%'}}>
           <div style={{display: 'flex'}}>
-            <div style={{width: '60%'}}>
+            <div style={{width: '60%', minWidth: '6em'}}>
               <>
                 <BigNumberInput
                   adornment="ESD"
@@ -89,7 +89,7 @@ function BondUnbond({
                 />
               </>
             </div>
-            <div style={{width: '40%'}}>
+            <div style={{width: '40%', minWidth: '7em'}}>
               <Button
                 wide
                 icon={<IconCircleMinus/>}

--- a/src/components/Wallet/Header.tsx
+++ b/src/components/Wallet/Header.tsx
@@ -19,20 +19,20 @@ const STATUS_MAP = ["Frozen", "Fluid", "Locked"];
 const AccountPageHeader = ({
   accountESDBalance, accountESDSBalance, totalESDSSupply, accountStagedBalance, accountBondedBalance, accountStatus,
 }: AccountPageHeaderProps) => (
-  <div style={{ padding: '2%', display: 'flex', alignItems: 'center' }}>
-    <div style={{ width: '20%' }}>
+  <div style={{ padding: '2%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Balance" balance={accountESDBalance} suffix={" ESD"}/>
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Staged" balance={accountStagedBalance}  suffix={" ESD"}/>
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="Bonded" balance={accountBondedBalance} suffix={" ESD"} />
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <BalanceBlock asset="DAO Ownership" balance={ownership(accountESDSBalance, totalESDSSupply)}  suffix={"%"}/>
     </div>
-    <div style={{ width: '20%' }}>
+    <div style={{ flexBasis: '20%' }}>
       <TextBlock label="Status" text={STATUS_MAP[accountStatus]}/>
     </div>
   </div>

--- a/src/components/Wallet/WithdrawDeposit.tsx
+++ b/src/components/Wallet/WithdrawDeposit.tsx
@@ -29,15 +29,15 @@ function WithdrawDeposit({
   return (
     <Box heading="Stage">
       {allowance.comparedTo(MAX_UINT256) === 0 ?
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total Issued */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Staged" balance={stagedBalance} suffix={"ESD"}/>
           </div>
           {/* Deposit Døllar into DAO */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '6em'}}>
                 <>
                   <BigNumberInput
                     adornment="ESD"
@@ -52,7 +52,7 @@ function WithdrawDeposit({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '6em'}}>
                 <Button
                   wide
                   icon={<IconCirclePlus/>}
@@ -68,11 +68,11 @@ function WithdrawDeposit({
               </div>
             </div>
           </div>
-          <div style={{width: '6%'}}/>
+          <div style={{flexBasis: '6%'}}/>
           {/* Withdraw Døllar from DAO */}
-          <div style={{width: '32%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '32%', paddingTop: '2%'}}>
             <div style={{display: 'flex'}}>
-              <div style={{width: '60%'}}>
+              <div style={{width: '60%', minWidth: '7em'}}>
                 <>
                   <BigNumberInput
                     adornment="ESD"
@@ -87,7 +87,7 @@ function WithdrawDeposit({
                   />
                 </>
               </div>
-              <div style={{width: '40%'}}>
+              <div style={{width: '40%', minWidth: '7em'}}>
                 <Button
                   wide
                   icon={<IconCircleMinus/>}
@@ -105,14 +105,14 @@ function WithdrawDeposit({
           </div>
         </div>
         :
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flexWrap: 'wrap'}}>
           {/* total Issued */}
-          <div style={{width: '30%'}}>
+          <div style={{flexBasis: '30%'}}>
             <BalanceBlock asset="Staged" balance={stagedBalance} suffix={"ESD"}/>
           </div>
-          <div style={{width: '40%'}}/>
+          <div style={{flexBasis: '40%'}}/>
           {/* Approve DAO to spend Døllar */}
-          <div style={{width: '30%', paddingTop: '2%'}}>
+          <div style={{flexBasis: '30%', paddingTop: '2%'}}>
             <Button
               wide
               icon={<IconCirclePlus />}


### PR DESCRIPTION
This PR applies the following style changes to improve the rendering on mobile browsers:

1. add `flexWrap: wrap` to content area divs
2. change `width` properties to `flexBasis`
3. add `minWidth` properties to text input and button controls so they do not shrink below a reasonable threshold

The navigation bar requires more sophisticated redesign for mobile and so has not been modified. It is functional, if ugly, in Metamask mobile.