### PR TITLE
Cosmetic improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
             </Switch>
         }
         <div style={{height: '128px', width: '100%'}}/>
-        <Footer theme={theme}/>
+        <Footer/>
       </Main>
     </Router>
   );

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { LinkBase } from '@aragon/ui';
+import { useTheme } from '@aragon/ui';
 
-function Footer({ theme } : { theme:string }) {
+function Footer() {
   const history = useHistory();
+  const theme = useTheme();
 
   return (
     <>
       <div style={{
-        borderTop: theme === 'light' ? '1px solid rgb(33, 43, 54, 0.1)' :'1px solid #405071',
-        backgroundColor: theme === 'light' ? '#F8F8F8' : '#35425e',
+        borderTop: '1px solid ' + theme.border,
+        backgroundColor: theme.surface,
         textAlign: 'center',
         position: 'fixed',
         left: '0',

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -76,11 +76,11 @@ function HomePage({user}: HomePageProps) {
 
         <div style={{ flexBasis: '30%' }}>
           <MainButton
-            title="Governance"
-            description="Vote on upgrades."
-            icon={<i className="fas fa-poll"/>}
+            title="LP Rewards"
+            description="Earn rewards for providing liquidity."
+            icon={<i className="fas fa-parachute-box"/>}
             onClick={() => {
-              history.push('/governance/');
+              history.push('/pool/');
             }}
           />
         </div>
@@ -97,24 +97,24 @@ function HomePage({user}: HomePageProps) {
         </div>
       </div>
       <div style={{ padding: '1%', display: 'flex', flexWrap: 'wrap', alignItems: 'center' }}>
-        <div style={{ flexBasis: '30%', marginRight: '3%', marginLeft: '2%'  }}>
+        <div style={{ flexBasis: '30%', marginRight: '3%', marginLeft: '2%' }}>
           <MainButton
-            title="Trade"
-            description="Trade døllar tokens."
-            icon={<i className="fas fa-exchange-alt"/>}
+            title="Governance"
+            description="Vote on upgrades."
+            icon={<i className="fas fa-poll"/>}
             onClick={() => {
-              history.push('/trade/');
+              history.push('/governance/');
             }}
           />
         </div>
 
         <div style={{ flexBasis: '30%' }}>
           <MainButton
-            title="LP Rewards"
-            description="Earn rewards for providing liquidity."
-            icon={<i className="fas fa-parachute-box"/>}
+            title="Trade"
+            description="Trade døllar tokens."
+            icon={<i className="fas fa-exchange-alt"/>}
             onClick={() => {
-              history.push('/pool/');
+              history.push('/trade/');
             }}
           />
         </div>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -37,13 +37,19 @@ function NavBar({
           <></>
         ) : (
           <>
-            <div style={{ height: '100%' }}>
-              <BackButton
-                onClick={() => {
-                  history.goBack();
-                }}
-              />
-            </div>
+            {
+              isHome ? (
+                <></>
+              ) : (
+                <div style={{ height: '100%' }}>
+                  <BackButton
+                    onClick={() => {
+                      history.goBack();
+                    }}
+                  />
+                </div>                
+              )
+            }
             <LinkButton
               title="Home"
               onClick={() => {

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -59,18 +59,25 @@ function NavBar({
               isSelected={page.includes('/wallet')}
             />
             <LinkButton
-              title="Rewards"
+              title="Liquidity"
               onClick={() => {
                 history.push('/pool/');
               }}
               isSelected={page.includes('/pool')}
             />
             <LinkButton
-              title="Coupons"
+              title="Regulation"
               onClick={() => {
-                history.push('/coupons/');
+                history.push('/regulation/');
               }}
-              isSelected={page.includes('/coupons')}
+              isSelected={page.includes('/regulation')}
+            />
+            <LinkButton
+              title="Governance"
+              onClick={() => {
+                history.push('/governance/');
+              }}
+              isSelected={page.includes('/governance')}
             />
             <LinkButton
               title="Trade"
@@ -80,11 +87,11 @@ function NavBar({
               isSelected={page.includes('/trade')}
             />
             <LinkButton
-              title="Governance"
+              title="Coupons"
               onClick={() => {
-                history.push('/governance/');
+                history.push('/coupons/');
               }}
-              isSelected={page.includes('/governance')}
+              isSelected={page.includes('/coupons')}
             />
           </>
         )
@@ -108,7 +115,7 @@ type linkButtonProps = {
 
 function LinkButton({ title, onClick, isSelected = false }:linkButtonProps) {
   return (
-    <div style={{ paddingLeft: 40 }}>
+    <div style={{ paddingLeft: 30 }}>
       <LinkBase onClick={onClick}>
         <div style={{ padding: '1%', opacity: isSelected ? 1 : 0.5, fontSize: 17 }}>{title}</div>
       </LinkBase>

--- a/src/components/Regulation/Header.tsx
+++ b/src/components/Regulation/Header.tsx
@@ -48,7 +48,7 @@ const RegulationHeader = ({
             <BalanceBlock asset="DAO" balance={ownership(daoTotalSupply, totalSupply)} suffix="%" />
           </div>
           <div style={{ flexBasis: '25%' }}>
-            <BalanceBlock asset="Oracle" balance={ownership(poolTotalSupply, totalSupply)} suffix="%" />
+            <BalanceBlock asset="Uniswap" balance={ownership(poolTotalSupply, totalSupply)} suffix="%" />
           </div>
           <div style={{ flexBasis: '25%' }}>
             <BalanceBlock asset="Circulating" balance={ownership(circulatingSupply, totalSupply)} suffix="%" />


### PR DESCRIPTION
Some easy cosmetic improvements

- Re-order homepage tabs: Wallet, LP Rewards, Regulation, Governance, Trade, Coupons
- Change "Oracle" in Supply allocation to "Uniswap"
- Change "Rewards" nav item label to "Liquidity"
- Remove back button on home page
- Refactor Footer to use the AragonUI theme colors