### PR TITLE
Add warning to coupon page

### DIFF
--- a/src/components/CouponMarket/ModalWarning.tsx
+++ b/src/components/CouponMarket/ModalWarning.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Header, Modal, Button, useTheme } from '@aragon/ui';
+import { getPreference, storePreference } from "../../utils/storage";
+import { COUPON_EXPIRATION } from "../../constants/values";
+
+function ModalWarning() {
+  const storedShowWarning = getPreference('showCouponWarning', '1');
+  const [showWarning, setShowWarning] = useState(storedShowWarning === '1');
+  const theme = useTheme();
+
+  return (
+    <Modal visible={showWarning} closeButton={false}>
+      <div style={{ width: '100%' }}>
+        <div style={{ fontSize: 24, padding: 3, color: theme.warning }}>
+          Warning
+        </div>
+
+        <div style={{
+          marginLeft: '3%',
+          fontSize: 16,
+          padding: 5
+        }}>
+          <div>
+            By purchasing coupons the buyer incurs significant risk of loss.
+            Coupons will only become redeemable during the next supply
+            expansion. Each expansionary epoch, a trache of rewards are
+            reserved for coupon redemptions by the DAO. At that time, the
+            redemption process is first come, first served. Coupon redemption
+            is not guaranteed.
+          </div>
+
+          <div style={{
+            padding: 10,
+            textAlign: 'center',
+            color: theme.warningSurfaceContent
+          }}>
+            Coupons will expire worthless if not redeemed
+            within {COUPON_EXPIRATION} epochs.
+          </div>
+        </div>
+
+        <div style={{ textAlign: 'right' }}>
+          <Button
+            label={'I understand'}
+            onClick={() => {
+              storePreference('showCouponWarning', '0');
+              setShowWarning(false);
+            }}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default ModalWarning;

--- a/src/components/CouponMarket/index.tsx
+++ b/src/components/CouponMarket/index.tsx
@@ -15,6 +15,7 @@ import {toTokenUnitsBN} from "../../utils/number";
 import BigNumber from "bignumber.js";
 import PurchaseCoupons from "./PurchaseCoupons";
 import PurchaseHistory from "./PurchaseHistory";
+import ModalWarning from "./ModalWarning";
 import IconHeader from "../common/IconHeader";
 import {getPreference, storePreference} from "../../utils/storage";
 import {CheckBox} from "../common";
@@ -108,6 +109,8 @@ function CouponMarket({ user }: {user: string}) {
 
   return (
     <>
+      <ModalWarning/>
+
       <IconHeader icon={<i className="fas fa-ticket-alt"/>} text="Coupon Market"/>
 
       <CouponMarketHeader

--- a/src/constants/values.js
+++ b/src/constants/values.js
@@ -3,3 +3,4 @@ import BigNumber from 'bignumber.js';
 // eslint-disable-next-line import/prefer-default-export
 export const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
 export const GOVERNANCE_QUORUM = new BigNumber('0.33');
+export const COUPON_EXPIRATION = 90


### PR DESCRIPTION
Add a modal warning to the coupon page to inform potential buyers of the risks. User acknowledgement is saved to local storage so the warning will only show once.