### PR TITLE
Support for EIP-16 style coupons

### DIFF
--- a/src/components/CouponMarket/index.tsx
+++ b/src/components/CouponMarket/index.tsx
@@ -6,7 +6,7 @@ import {
   getCouponPremium,
   getTokenAllowance,
   getTokenBalance,
-  getTokenTotalSupply, getTotalCoupons,
+  getTokenTotalSupply, getTotalCoupons, getTotalCouponsUnderlying,
   getTotalDebt, getTotalRedeemable,
 } from '../../utils/infura';
 import {ESD, ESDS} from "../../constants/tokens";
@@ -75,16 +75,19 @@ function CouponMarket({ user }: {user: string}) {
     let isCancelled = false;
 
     async function updateUserInfo() {
-      const [supplyStr, debtStr, couponsStr, redeemableStr] = await Promise.all([
+      const [supplyStr, debtStr, couponsPremiumStr, couponsPrincipalStr, redeemableStr] = await Promise.all([
         getTokenTotalSupply(ESD.addr),
         getTotalDebt(ESDS.addr),
         getTotalCoupons(ESDS.addr),
+        getTotalCouponsUnderlying(ESDS.addr),
         getTotalRedeemable(ESDS.addr),
       ]);
 
       const totalSupply = toTokenUnitsBN(supplyStr, ESD.decimals);
       const totalDebt = toTokenUnitsBN(debtStr, ESD.decimals);
-      const totalCoupons = toTokenUnitsBN(couponsStr, ESD.decimals);
+      const totalCoupons = toTokenUnitsBN(couponsPrincipalStr, ESD.decimals).plus(
+        toTokenUnitsBN(couponsPremiumStr, ESD.decimals)
+      );
       const totalRedeemable = toTokenUnitsBN(redeemableStr, ESD.decimals);
 
       if (!isCancelled) {

--- a/src/components/Regulation/Header.tsx
+++ b/src/components/Regulation/Header.tsx
@@ -21,6 +21,7 @@ type RegulationHeaderProps = {
 
   totalDebt: BigNumber,
   totalCoupons: BigNumber,
+  totalCouponsUnderlying: BigNumber,
   couponPremium: BigNumber,
 };
 
@@ -29,7 +30,7 @@ const RegulationHeader = ({
   totalBonded, totalStaged, totalRedeemable,
   poolLiquidity, poolRewarded, poolClaimable,
   legacyPoolRewarded, legacyPoolClaimable,
-  totalDebt, totalCoupons, couponPremium
+  totalDebt, totalCoupons, totalCouponsUnderlying, couponPremium
 }: RegulationHeaderProps) => {
   const daoTotalSupply = totalBonded.plus(totalStaged).plus(totalRedeemable);
   const poolTotalSupply = poolLiquidity.plus(poolRewarded).plus(poolClaimable);

--- a/src/components/Regulation/index.tsx
+++ b/src/components/Regulation/index.tsx
@@ -3,8 +3,9 @@ import { Header } from '@aragon/ui';
 
 import {
   getCouponPremium,
+  getTotalCoupons, getTotalCouponsUnderlying,
   getPoolTotalClaimable, getPoolTotalRewarded, getTokenBalance,
-  getTokenTotalSupply, getTotalBonded, getTotalCoupons, getTotalDebt, getTotalRedeemable, getTotalStaged,
+  getTokenTotalSupply, getTotalBonded, getTotalDebt, getTotalRedeemable, getTotalStaged,
 } from '../../utils/infura';
 import {ESD, ESDS, UNI} from "../../constants/tokens";
 import {toTokenUnitsBN} from "../../utils/number";
@@ -29,6 +30,7 @@ function Regulation({ user }: {user: string}) {
   const [legacyPoolTotalClaimable, setLegacyPoolTotalClaimable] = useState(new BigNumber(0));
   const [totalDebt, setTotalDebt] = useState(new BigNumber(0));
   const [totalCoupons, setTotalCoupons] = useState(new BigNumber(0));
+  const [totalCouponsUnderlying, setTotalCouponsUnderlying] = useState(new BigNumber(0));
   const [couponPremium, setCouponPremium] = useState(new BigNumber(0));
 
   useEffect(() => {
@@ -43,7 +45,7 @@ function Regulation({ user }: {user: string}) {
         totalBondedStr, totalStagedStr, totalRedeemableStr,
         poolLiquidityStr, poolTotalRewardedStr, poolTotalClaimableStr,
         legacyPoolTotalRewardedStr, legacyPoolTotalClaimableStr,
-        totalDebtStr, totalCouponsStr
+        totalDebtStr, totalCouponsStr, totalCouponsUnderlyingStr
       ] = await Promise.all([
         getTokenTotalSupply(ESD.addr),
 
@@ -60,6 +62,7 @@ function Regulation({ user }: {user: string}) {
 
         getTotalDebt(ESDS.addr),
         getTotalCoupons(ESDS.addr),
+        getTotalCouponsUnderlying(ESDS.addr),
       ]);
 
       if (!isCancelled) {
@@ -78,6 +81,7 @@ function Regulation({ user }: {user: string}) {
 
         setTotalDebt(toTokenUnitsBN(totalDebtStr, ESD.decimals));
         setTotalCoupons(toTokenUnitsBN(totalCouponsStr, ESD.decimals));
+        setTotalCouponsUnderlying(toTokenUnitsBN(totalCouponsUnderlyingStr, ESD.decimals));
 
         if (new BigNumber(totalDebtStr).isGreaterThan(ONE_COUPON)) {
           const couponPremiumStr = await getCouponPremium(ESDS.addr, ONE_COUPON)
@@ -117,6 +121,7 @@ function Regulation({ user }: {user: string}) {
 
         totalDebt={totalDebt}
         totalCoupons={totalCoupons}
+        totalCouponsUnderlying={totalCouponsUnderlying}
         couponPremium={couponPremium}
       />
 

--- a/src/utils/infura.js
+++ b/src/utils/infura.js
@@ -160,7 +160,7 @@ export const getTotalCoupons = async (dao) => {
  * @param {string} dao address
  * @return {Promise<string>}
  */
-export const getTotalCouponUnderlying = async (dao) => {
+export const getTotalCouponsUnderlying = async (dao) => {
   const daoContract = new web3.eth.Contract(daoAbi, dao);
   return daoContract.methods.totalCouponUnderlying().call();
 };
@@ -279,10 +279,22 @@ export const getBalanceOfCoupons = async (dao, account, epoch) => {
  *
  * @param {string} dao address
  * @param {string} account address
+ * @param {number[]} epochs number[]
+ * @return {Promise<string[]>}
+ */
+export const getBatchBalanceOfCoupons = async (dao, account, epochs) => {
+  const calls = epochs.map((epoch) => getBalanceOfCoupons(dao, account, epoch));
+  return Promise.all(calls);
+};
+
+/**
+ *
+ * @param {string} dao address
+ * @param {string} account address
  * @param {number} epoch number
  * @return {Promise<string>}
  */
-export const getBalanceOfCouponUnderlying = async (dao, account, epoch) => {
+export const getBalanceOfCouponsUnderlying = async (dao, account, epoch) => {
   const daoContract = new web3.eth.Contract(daoAbi, dao);
   return daoContract.methods.balanceOfCouponUnderlying(account, epoch).call();
 };
@@ -294,8 +306,8 @@ export const getBalanceOfCouponUnderlying = async (dao, account, epoch) => {
  * @param {number[]} epochs number[]
  * @return {Promise<string[]>}
  */
-export const getBatchBalanceOfCoupons = async (dao, account, epochs) => {
-  const calls = epochs.map((epoch) => getBalanceOfCoupons(dao, account, epoch));
+export const getBatchBalanceOfCouponsUnderlying = async (dao, account, epochs) => {
+  const calls = epochs.map((epoch) => getBalanceOfCouponsUnderlying(dao, account, epoch));
   return Promise.all(calls);
 };
 

--- a/src/utils/web3.js
+++ b/src/utils/web3.js
@@ -273,6 +273,19 @@ export const redeemCoupons = async (dao, epoch, amount) => {
     });
 };
 
+export const migrateCoupons = async (dao, epoch) => {
+  const account = await checkConnectedAndGetAddress();
+  const daoContract = new window.web3.eth.Contract(daoAbi, dao);
+  await daoContract.methods
+    .migrateCoupons(epoch)
+    .send({
+      from: account,
+    })
+    .on('transactionHash', (hash) => {
+      notify.hash(hash);
+    });
+};
+
 export const recordVote = async (dao, candidate, voteType) => {
   const account = await checkConnectedAndGetAddress();
   const daoContract = new window.web3.eth.Contract(daoAbi, dao);


### PR DESCRIPTION
In support of EIP-16:
- use new getters for coupon principal/premium queries
- detect pre EIP-16 style coupons and provide a migrate button for calling `migrateCoupons`
- report aggregate total coupons figure as combined principal + premium

Because I was there:
- label fully redeemed coupons as Redeemed
- disable Redeem button when the Redeemable pool is empty, show lock icon