### PR TITLE
Persistent wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ function App() {
   const storedTheme = getPreference('theme', 'light');
 
   const [hasWeb3, setHasWeb3] = useState(false);
-  const [user, setUser] = useState(''); // the current connected user
   const [theme, setTheme] = useState(storedTheme);
 
   const updateTheme = (newTheme: string) => {
@@ -49,7 +48,7 @@ function App() {
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  });
 
   return (
     <Router>
@@ -65,23 +64,23 @@ function App() {
         }}
       >
         <Main assetsUrl={`${process.env.PUBLIC_URL}/aragon-ui/`} theme={theme} layout={false}>
-          <NavBar hasWeb3={hasWeb3} user={user} setUser={setUser} />
+          <NavBar hasWeb3={hasWeb3} />
           <Layout>
           {
             hasWeb3 ?
               <Switch>
-                <Route path="/dao/:override"><Wallet user={user}/></Route>
-                <Route path="/dao/"><Wallet user={user}/></Route>
-                <Route path="/epoch/"><EpochDetail user={user}/></Route>
-                <Route path="/coupons/:override"><CouponMarket user={user}/></Route>
-                <Route path="/coupons/"><CouponMarket user={user}/></Route>
-                <Route path="/governance/candidate/:candidate"><Candidate user={user}/></Route>
-                <Route path="/governance/"><Governance user={user}/></Route>
-                <Route path="/trade/"><Trade user={user}/></Route>
-                <Route path="/regulation/"><Regulation user={user}/></Route>
-                <Route path="/pool/:override"><Pool user={user}/></Route>
-                <Route path="/pool/"><Pool user={user}/></Route>
-                <Route path="/"><HomePage user={user}/></Route>
+                <Route path="/dao/:override"><Wallet /></Route>
+                <Route path="/dao/"><Wallet /></Route>
+                <Route path="/epoch/"><EpochDetail /></Route>
+                <Route path="/coupons/:override"><CouponMarket /></Route>
+                <Route path="/coupons/"><CouponMarket /></Route>
+                <Route path="/governance/candidate/:candidate"><Candidate /></Route>
+                <Route path="/governance/"><Governance /></Route>
+                <Route path="/trade/"><Trade /></Route>
+                <Route path="/regulation/"><Regulation /></Route>
+                <Route path="/pool/:override"><Pool /></Route>
+                <Route path="/pool/"><Pool /></Route>
+                <Route path="/"><HomePage /></Route>
               </Switch>
               :
               <Switch>

--- a/src/components/Candidate/index.tsx
+++ b/src/components/Candidate/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Header, IdentityBadge } from '@aragon/ui';
 import { useParams } from 'react-router-dom';
+import { useWallet } from 'use-wallet';
+import BigNumber from "bignumber.js";
+import { Header, IdentityBadge } from '@aragon/ui';
 
 import {
   getApproveFor, getEpoch, getIsInitialized, getPeriodFor,
@@ -11,7 +13,6 @@ import {
 } from '../../utils/infura';
 import {ESDS} from "../../constants/tokens";
 import {toTokenUnitsBN} from "../../utils/number";
-import BigNumber from "bignumber.js";
 import Vote from "./Vote";
 import VoteHeader from "./VoteHeader";
 import CommitHeader from "./CommitHeader";
@@ -19,8 +20,10 @@ import Commit from "./Commit";
 import IconHeader from "../common/IconHeader";
 import {proposalStatus} from "../../utils/gov";
 
-function Candidate({ user }: {user: string}) {
+function Candidate() {
   const { candidate } = useParams();
+  const { account } = useWallet();
+  const user = account || '';
 
   const [approveFor, setApproveFor] = useState(new BigNumber(0));
   const [rejectFor, setRejectFor] = useState(new BigNumber(0));

--- a/src/components/CouponMarket/index.tsx
+++ b/src/components/CouponMarket/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { Header } from '@aragon/ui';
 import { useParams } from 'react-router-dom';
+import { useWallet } from 'use-wallet';
+import BigNumber from "bignumber.js";
+import { Header } from '@aragon/ui';
 
 import {
   getCouponPremium,
@@ -12,7 +14,6 @@ import {
 import {ESD, ESDS} from "../../constants/tokens";
 import CouponMarketHeader from "./Header";
 import {toTokenUnitsBN} from "../../utils/number";
-import BigNumber from "bignumber.js";
 import PurchaseCoupons from "./PurchaseCoupons";
 import PurchaseHistory from "./PurchaseHistory";
 import ModalWarning from "./ModalWarning";
@@ -22,11 +23,10 @@ import {CheckBox} from "../common";
 
 const ONE_COUPON = new BigNumber(10).pow(18);
 
-function CouponMarket({ user }: {user: string}) {
+function CouponMarket() {
+  const { account } = useWallet();
   const { override } = useParams();
-  if (override) {
-    user = override;
-  }
+  const user = override ? override : account || '';
 
   const storedHideRedeemed = getPreference('hideRedeemedCoupons', '0');
 

--- a/src/components/EpochDetail/AdvanceEpoch.tsx
+++ b/src/components/EpochDetail/AdvanceEpoch.tsx
@@ -7,13 +7,11 @@ import NumberBlock from "../common/NumberBlock";
 import {ESDS} from "../../constants/tokens";
 
 type AdvanceEpochProps = {
-  user: string,
   epoch: number,
   epochTime: number,
 }
 
 function AdvanceEpoch({
-  user,
   epoch,
   epochTime,
 }: AdvanceEpochProps) {
@@ -34,7 +32,7 @@ function AdvanceEpoch({
             onClick={() => {
               advance(ESDS.addr);
             }}
-            disabled={user === '' || epoch >= epochTime}
+            disabled={epoch >= epochTime}
           />
         </div>
       </div>

--- a/src/components/EpochDetail/index.tsx
+++ b/src/components/EpochDetail/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useWallet } from 'use-wallet';
 import { Header } from '@aragon/ui';
 
 import {getEpoch, getEpochTime,
@@ -8,7 +9,8 @@ import AdvanceEpoch from './AdvanceEpoch';
 import EpochPageHeader from "./Header";
 import IconHeader from "../common/IconHeader";
 
-function EpochDetail({ user }: {user: string}) {
+function EpochDetail() {
+  const { account } = useWallet();
 
   const [epoch, setEpoch] = useState(0);
   const [epochTime, setEpochTime] = useState(0);
@@ -34,7 +36,7 @@ function EpochDetail({ user }: {user: string}) {
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  }, [account]);
 
   return (
     <>
@@ -48,7 +50,6 @@ function EpochDetail({ user }: {user: string}) {
       <Header primary="Advance Epoch" />
 
       <AdvanceEpoch
-        user={user}
         epoch={epoch}
         epochTime={epochTime}
       />

--- a/src/components/Governance/index.tsx
+++ b/src/components/Governance/index.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { useWallet } from 'use-wallet';
+import BigNumber from "bignumber.js";
 import { Header } from '@aragon/ui';
 
 import {
@@ -9,14 +11,15 @@ import {
 } from '../../utils/infura';
 import {ESDS} from "../../constants/tokens";
 import {toTokenUnitsBN} from "../../utils/number";
-import BigNumber from "bignumber.js";
 import GovernanceHeader from "./Header";
 import ProposeCandidate from "./ProposeCandidate";
 import CandidateHistory from "./CandidateHistory";
 import IconHeader from "../common/IconHeader";
 import {canPropose} from "../../utils/gov";
 
-function Governance({ user }: {user: string}) {
+function Governance() {
+  const { account } = useWallet();
+  const user = account || '';
 
   const [stake, setStake] = useState(new BigNumber(0));
   const [totalStake, setTotalStake] = useState(new BigNumber(0));

--- a/src/components/HomePage/index.tsx
+++ b/src/components/HomePage/index.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import { useHistory } from 'react-router-dom';
-import {
-  Box, LinkBase, Tag,
-} from '@aragon/ui';
+import { useWallet } from 'use-wallet';
+import { Box, LinkBase, Tag } from '@aragon/ui';
+
 import EpochBlock from "../common/EpochBlock";
 
 function epochformatted() {
@@ -22,11 +22,8 @@ function epochformatted() {
   return `${epoch}-0${epochHour}:${epochMinute > 9 ? epochMinute : "0" + epochMinute.toString()}:${epochRemainder > 9 ? epochRemainder : "0" + epochRemainder.toString()}`;
 }
 
-type HomePageProps = {
-  user: string
-};
-
-function HomePage({user}: HomePageProps) {
+function HomePage() {
+  const { account } = useWallet();
   const history = useHistory();
 
   const [epochTime, setEpochTime] = useState("0-00:00:00");
@@ -47,7 +44,7 @@ function HomePage({user}: HomePageProps) {
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  }, [account]);
 
   return (
     <>

--- a/src/components/NavBar/ConnectButton.tsx
+++ b/src/components/NavBar/ConnectButton.tsx
@@ -10,23 +10,19 @@ import TotalBalance from "./TotalBalance";
 import ConnectModal from './ConnectModal';
 
 type connectButtonProps = {
-  hasWeb3: boolean,
-  user: string,
-  setUser: Function
+  hasWeb3: boolean;
 }
 
-function ConnectButton({ hasWeb3, user, setUser }: connectButtonProps) {
-  const { status, reset } = useWallet();
+function ConnectButton({ hasWeb3 }: connectButtonProps) {
+  const { account, status, reset } = useWallet();
 
   const [isModalOpen, setModalOpen] = useState(false);
 
   const connectWeb3 = async (wallet) => {
     connect(wallet.ethereum);
-    setUser(wallet.account);
   };
 
   const disconnectWeb3 = async () => {
-    setUser('');
     reset();
   };
 
@@ -44,12 +40,12 @@ function ConnectButton({ hasWeb3, user, setUser }: connectButtonProps) {
               </LinkBase>
             </div>
             <div style={{flex: '1', textAlign: 'right'}}>
-              <IdentityBadge entity={user} />
+              <IdentityBadge entity={account || ''} />
             </div>
           </div>
           <div style={{display: 'flex'}}>
             <div style={{flex: '1', textAlign: 'right'}}>
-              <TotalBalance user={user} />
+              <TotalBalance user={account || ''} />
             </div>
           </div>
         </Box>

--- a/src/components/NavBar/ConnectButton.tsx
+++ b/src/components/NavBar/ConnectButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useWallet } from 'use-wallet';
 
 import {
@@ -6,6 +6,7 @@ import {
 } from '@aragon/ui';
 
 import { connect } from '../../utils/web3';
+import { storePreference, getPreference, removePreference } from '../../utils/storage';
 import TotalBalance from "./TotalBalance";
 import ConnectModal from './ConnectModal';
 
@@ -14,21 +15,42 @@ type connectButtonProps = {
 }
 
 function ConnectButton({ hasWeb3 }: connectButtonProps) {
-  const { account, status, reset } = useWallet();
+  const wallet = useWallet();
 
   const [isModalOpen, setModalOpen] = useState(false);
 
-  const connectWeb3 = async (wallet) => {
-    connect(wallet.ethereum);
+  const connectWeb3 = async () => {
+    if (wallet.account) {
+      storePreference('account', wallet.account);
+      storePreference('walletProvider', wallet.connector);
+      connect(wallet.ethereum);
+    }
   };
 
   const disconnectWeb3 = async () => {
-    reset();
+    removePreference('account');
+    removePreference('walletProvider');
+    setModalOpen(false);
+    wallet.reset();
   };
 
   const toggleModal = () => setModalOpen(!isModalOpen);
 
-  return status === 'connected' ? (
+  useEffect(() => {
+    const localAccount = getPreference('account', '');
+    const walletProvider = getPreference('walletProvider', '');
+
+    if (!wallet.account && localAccount !== '' && walletProvider !== '') {
+      if (walletProvider === 'injected')
+        wallet.connect('injected');
+      else if (walletProvider === 'walletconnect')
+        wallet.connect('walletconnect');
+      else if (walletProvider === 'walletlink')
+        wallet.connect('walletlink');
+    }
+  });
+
+  return wallet.status === 'connected' ? (
     <div style={{display: 'flex'}}>
       <div style={{flex: '1'}}/>
       <div>
@@ -40,12 +62,12 @@ function ConnectButton({ hasWeb3 }: connectButtonProps) {
               </LinkBase>
             </div>
             <div style={{flex: '1', textAlign: 'right'}}>
-              <IdentityBadge entity={account || ''} />
+              <IdentityBadge entity={wallet.account || ''} />
             </div>
           </div>
           <div style={{display: 'flex'}}>
             <div style={{flex: '1', textAlign: 'right'}}>
-              <TotalBalance user={account || ''} />
+              <TotalBalance user={wallet.account || ''} />
             </div>
           </div>
         </Box>

--- a/src/components/NavBar/ConnectModal.tsx
+++ b/src/components/NavBar/ConnectModal.tsx
@@ -11,26 +11,18 @@ type ConnectModalProps = {
 function ConnectModal({
   visible, onClose, onConnect
 }:ConnectModalProps) {
-  const wallet = useWallet();
+  const { account, connect } = useWallet();
 
-  const connectMetamask = () => {
-    wallet.connect("injected");
-  };
-
-  const connectWalletConnect = () => {
-    wallet.connect("walletconnect");
-  };
-
-  const connectCoinbase = () => {
-    wallet.connect("walletlink");
+  const handleConnect = (connector) => {
+    connect(connector);
   };
 
   useEffect(() => {
-    if (wallet.account) {
-      onConnect && onConnect(wallet);
+    if (account) {
+      onConnect && onConnect();
       onClose && onClose();
     }
-  }, [wallet, onConnect, onClose]);
+  }, [account, onConnect, onClose]);
 
   return (
     <Modal visible={visible} onClose={onClose}>
@@ -41,7 +33,7 @@ function ConnectModal({
           wide
           label={'Metamask'}
           icon={<img src={`./wallets/metamask-fox.svg`} style={{ height: 24 }} alt="Metamask"/>}
-          onClick={connectMetamask}
+          onClick={() => {handleConnect('injected')}}
         />
       </div>
       <div style={{width: '50%', margin: 'auto', padding: '1%'}}>
@@ -49,7 +41,7 @@ function ConnectModal({
           wide
           label={'WalletConnect'}
           icon={<img src={`./wallets/wallet-connect.svg`} style={{ height: 24 }} alt="WalletConnect"/>}
-          onClick={connectWalletConnect}
+          onClick={() => {handleConnect('walletconnect')}}
         />
       </div>
       <div style={{width: '50%', margin: 'auto', padding: '1%'}}>
@@ -57,7 +49,7 @@ function ConnectModal({
           wide
           label={'Coinbase Wallet'}
           icon={<img src={`./wallets/coinbase-wallet.png`} style={{ height: 24 }} alt="Coinbase Wallet"/>}
-          onClick={connectCoinbase}
+          onClick={() => {handleConnect('walletlink')}}
         />
       </div>
     </Modal>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -6,11 +6,9 @@ import ConnectButton from './ConnectButton';
 
 type NavbarProps = {
   hasWeb3: boolean;
-  user: string;
-  setUser: Function;
 };
 
-function NavBar({ hasWeb3, user, setUser }: NavbarProps) {
+function NavBar({ hasWeb3 }: NavbarProps) {
   const currentTheme = useTheme();
   const logoUrl = `./logo/logo_${currentTheme._name === 'light' ? 'black' : 'white'}.svg`;
 
@@ -42,7 +40,7 @@ function NavBar({ hasWeb3, user, setUser }: NavbarProps) {
               <LinkButton title="Coupons" to="/coupons/" />
             </div>
             <div style={{ width: '20%', textAlign: 'right' }}>
-              <ConnectButton hasWeb3={hasWeb3} user={user} setUser={setUser} />
+              <ConnectButton hasWeb3={hasWeb3} />
             </div>
           </div>
         </div>

--- a/src/components/Pool/index.tsx
+++ b/src/components/Pool/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-
+import { useWallet } from 'use-wallet';
 import BigNumber from 'bignumber.js';
+import { Header } from '@aragon/ui';
+
 import {
   getPoolBalanceOfBonded, getPoolBalanceOfClaimable,
   getPoolBalanceOfRewarded,
@@ -14,7 +16,6 @@ import {
 import {ESD, UNI, USDC} from "../../constants/tokens";
 import {POOL_EXIT_LOCKUP_EPOCHS} from "../../constants/values";
 import { toTokenUnitsBN } from '../../utils/number';
-import { Header } from '@aragon/ui';
 
 import WithdrawDeposit from "./WithdrawDeposit";
 import BondUnbond from "./BondUnbond";
@@ -28,11 +29,10 @@ import {DollarPool4} from "../../constants/contracts";
 
 
 
-function Pool({ user }: {user: string}) {
+function Pool() {
+  const { account } = useWallet();
   const { override } = useParams();
-  if (override) {
-    user = override;
-  }
+  const user = override ? override : account || '';
 
   const [poolAddress, setPoolAddress] = useState("");
   const [poolTotalBonded, setPoolTotalBonded] = useState(new BigNumber(0));

--- a/src/components/Regulation/RegulationHistory.tsx
+++ b/src/components/Regulation/RegulationHistory.tsx
@@ -1,14 +1,11 @@
 import React, {useEffect, useState} from 'react';
+import { useWallet } from 'use-wallet';
+import BigNumber from "bignumber.js";
 import { DataView } from '@aragon/ui';
 
 import {getAllRegulations} from '../../utils/infura';
 import {ESD, ESDS} from "../../constants/tokens";
 import {formatBN, toTokenUnitsBN} from "../../utils/number";
-import BigNumber from "bignumber.js";
-
-type RegulationHistoryProps = {
-  user: string,
-};
 
 type Regulation = {
   type: string,
@@ -57,9 +54,9 @@ function renderEntry({ type, data }: Regulation): string[] {
   ]
 }
 
-function RegulationHistory({
-  user,
-}: RegulationHistoryProps) {
+function RegulationHistory() {
+  const { account } = useWallet();
+
   const [regulations, setRegulations] = useState<Regulation[]>([]);
   const [page, setPage] = useState(0)
   const [initialized, setInitialized] = useState(false)
@@ -87,7 +84,7 @@ function RegulationHistory({
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  }, [account]);
 
   return (
     <DataView

--- a/src/components/Regulation/index.tsx
+++ b/src/components/Regulation/index.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { useWallet } from 'use-wallet';
+import BigNumber from "bignumber.js";
 import { Header } from '@aragon/ui';
 
 import {
@@ -9,7 +11,6 @@ import {
 } from '../../utils/infura';
 import {ESD, ESDS, UNI} from "../../constants/tokens";
 import {toTokenUnitsBN} from "../../utils/number";
-import BigNumber from "bignumber.js";
 import RegulationHeader from "./Header";
 import RegulationHistory from "./RegulationHistory";
 import IconHeader from "../common/IconHeader";
@@ -17,7 +18,8 @@ import {getLegacyPoolAddress, getPoolAddress} from "../../utils/pool";
 
 const ONE_COUPON = new BigNumber(10).pow(18);
 
-function Regulation({ user }: {user: string}) {
+function Regulation() {
+  const { account } = useWallet();
 
   const [totalSupply, setTotalSupply] = useState(new BigNumber(0));
   const [totalBonded, setTotalBonded] = useState(new BigNumber(0));
@@ -99,7 +101,7 @@ function Regulation({ user }: {user: string}) {
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  }, [account]);
 
   return (
     <>
@@ -127,9 +129,7 @@ function Regulation({ user }: {user: string}) {
 
       <Header primary="Regulation History" />
 
-      <RegulationHistory
-        user={user}
-      />
+      <RegulationHistory />
     </>
   );
 }

--- a/src/components/Trade/index.tsx
+++ b/src/components/Trade/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { useWallet } from 'use-wallet';
+import BigNumber from 'bignumber.js';
 import { LinkBase, Box } from '@aragon/ui';
 
-import BigNumber from 'bignumber.js';
 import { getTokenBalance } from '../../utils/infura';
 import { toTokenUnitsBN } from '../../utils/number';
 
@@ -10,7 +11,9 @@ import {ESD, UNI, USDC} from "../../constants/tokens";
 import IconHeader from "../common/IconHeader";
 
 
-function UniswapPool({ user }: {user: string}) {
+function UniswapPool() {
+  const { account } = useWallet();
+
   const [pairBalanceESD, setPairBalanceESD] = useState(new BigNumber(0));
   const [pairBalanceUSDC, setPairBalanceUSDC] = useState(new BigNumber(0));
 
@@ -39,7 +42,7 @@ function UniswapPool({ user }: {user: string}) {
       isCancelled = true;
       clearInterval(id);
     };
-  }, [user]);
+  }, [account]);
 
   return (
     <>

--- a/src/components/Wallet/index.tsx
+++ b/src/components/Wallet/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-
+import { useWallet } from 'use-wallet';
 import BigNumber from 'bignumber.js';
+
 import {
   getBalanceBonded,
   getBalanceOfStaged, getFluidUntil, getLockedUntil,
@@ -19,11 +20,10 @@ import IconHeader from "../common/IconHeader";
 import {getPoolAddress} from "../../utils/pool";
 import {DollarPool4} from "../../constants/contracts";
 
-function Wallet({ user }: {user: string}) {
+function Wallet() {
+  const { account } = useWallet();
   const { override } = useParams();
-  if (override) {
-    user = override;
-  }
+  const user = override ? override : account || '';
 
   const [userESDBalance, setUserESDBalance] = useState(new BigNumber(0));
   const [userESDAllowance, setUserESDAllowance] = useState(new BigNumber(0));

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -15,3 +15,11 @@ export function getPreference(key:string, defaultValue:string): string {
 export function storePreference(key:string, value:string):void {
   localStorage.setItem(key, value);
 }
+
+/**
+ * remove key from storage
+ * @param {string} key
+ */
+export function removePreference(key:string):void {
+  localStorage.removeItem(key);
+}


### PR DESCRIPTION
- Refactored top-level components to use `use-wallet` instead of receiving an account address in state
- Persist login info to local storage and use it to auto-login