### PR TITLE
Prevent home link from opening in a new tab

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -29,7 +29,12 @@ function NavBar({ hasWeb3, user, setUser }: NavbarProps) {
         <div style={{ maxWidth: '1100px', marginLeft: 'auto', marginRight: 'auto' }}>
           <div style={{ display: 'flex', paddingTop: '24px' }}>
             <div style={{ width: '20%', textAlign: 'left' }}>
-              <NavLink to="/" component={LinkBase} style={{ marginRight: '16px', height: '40px' }}>
+              <NavLink
+                to="/"
+                external={false}
+                component={LinkBase}
+                style={{ marginRight: '16px', height: '40px' }}
+              >
                 <img src={logoUrl} height="40px" alt="Empty Set Dollar" />
               </NavLink>
             </div>


### PR DESCRIPTION
I'm not sure why but aragon/ui is trying to open the "Home" link in the menu bar in a new browser tab which is extremely annoying. Adding `external={false}` to the component fixes the issue.